### PR TITLE
Fix overjump of entries

### DIFF
--- a/dmi_instascraper/instagram_scraper.py
+++ b/dmi_instascraper/instagram_scraper.py
@@ -171,7 +171,7 @@ class InstagramScraper(threading.Thread):
                     if posts_processed >= self.max_posts:
                         break
                     try:
-                        posts.append(chunk.__next__())
+                        posts.append(post)
                         posts[-1].query = query
                         posts_processed += 1
                     except StopIteration:


### PR DESCRIPTION
There is a bug which shrinks the scraped results down to the floored half amount of results. E.g. for an Instagram channel with 75 entries, only 37 results are scraped. This is due to the double access of the Iterator "chunk": by using access for looping through the Iterator, and by using the __next__() function, the Iterator drops 2 items instead of 1. This way, only every second result gets scraped. I resolved it by using the for-loop's iterator from the Iterator item instead of calling  __next__(). 